### PR TITLE
composerのターゲットパスが違っていたため、修正しました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Adds social share buttons.
 
 ## Get started
 ```
-$ composer require inc2734/mw-share-buttons
+$ composer require inc2734/wp-mw-share-buttons
 $ npm i
 $ npm run gulp build
 $ composer install


### PR DESCRIPTION
自分の環境でcomposerを使ってダウンロードしようとしたところ、composerのターゲットパスが「inc2734/mw-share-buttons」ではなく、「inc2734/wp-mw-share-buttons」でOKでしたので、修正をさせて頂きました。